### PR TITLE
Does not allow PRs to be merged with QA needed label. [POE-1014]

### DIFF
--- a/.github/wip.yml
+++ b/.github/wip.yml
@@ -1,0 +1,8 @@
+- terms:
+  - wip
+  - Work in progress
+  - 🚧
+  locations: title
+- terms: qa needed
+  locations: label_name
+


### PR DESCRIPTION
**Description**: This PR adds QA needed label as a term to enable WIP bot. It avoids PRs to be merged if QA needed label is setted.

**JIRA**: [POE-1014](http://jira.caremessage.org/browse/POE-1014)

**How to Verify**: N/A